### PR TITLE
fix numpy pinning

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 5cd5cb30e72eeaf202f0e5e180780b897570e889d2db328c689a5a263405c559
 
 build:
-  number: 0
+  number: 1
   script: python setup.py install --single-version-externally-managed --record=record.txt  # [win]
 
 requirements:
@@ -25,7 +25,7 @@ requirements:
     - numpy
   run:
     - python
-    - {{ pin_compatible('numpy', max_pin='x.x') }}
+    - {{ pin_compatible('numpy', min_pin='x.x', max_pin=None) }}
     - python-dateutil
     - pytz
 


### PR DESCRIPTION
The `numpy` version was incorrectly pinned, restricting the maximum version number of the run requirement to the one used for the build. See https://github.com/conda/conda/issues/6260.
I'm not too familiar with the new pinning mechanisms so I might be wrong, but I guess `min_pin='x.x', max_pin=None` should result in the desired pinning, right?