### PR TITLE
Update to 1.3.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: c554e6c9cf2d5ea1aba5979cc837b3649539ced0e18ece186f055450c86622e2
 
 build:
-  number: 3
+  number: 0
   script:
     - export PYTHONUNBUFFERED=1  # [ppc64le]
     - {{ PYTHON }} -m pip install -vv --no-deps --ignore-installed .  # [not unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: c554e6c9cf2d5ea1aba5979cc837b3649539ced0e18ece186f055450c86622e2
 
 build:
-  number: 0
+  number: 2
   script:
     - export PYTHONUNBUFFERED=1  # [ppc64le]
     - {{ PYTHON }} -m pip install -vv --no-deps --ignore-installed .  # [not unix]
@@ -37,7 +37,7 @@ requirements:
     - {{ pin_compatible('numpy') }}
     - python-dateutil >=2.7.3
     - pytz >=2017.3
-    # Recommended dependencies to achieve large speedups 
+    # Recommended dependencies to achieve large speedups
     # see https://pandas.pydata.org/pandas-docs/stable/getting_started/install.html#recommended-dependencies
     - numexpr >=2.7.0
     - bottleneck >=1.2.1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.2.5" %}
+{% set version = "1.3.0" %}
 
 package:
   name: pandas
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/pandas-dev/pandas/releases/download/v{{ version }}/pandas-{{ version }}.tar.gz
-  sha256: 14abb8ea73fce8aebbb1fb44bec809163f1c55241bcc1db91c2c780e97265033
+  sha256: c554e6c9cf2d5ea1aba5979cc837b3649539ced0e18ece186f055450c86622e2
 
 build:
   number: 0
@@ -26,20 +26,20 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
   host:
-    - python >=3.7.1
+    - python
     - pip
     - cython >=0.29.21
     - numpy >=1.17.3
     - setuptools >=38.6.0
     - wheel
   run:
-    - python >=3.7.1
+    - python
     - {{ pin_compatible('numpy') }}
     - python-dateutil >=2.7.3
     - pytz >=2017.3
     # Recommended dependencies to achieve large speedups 
     # see https://pandas.pydata.org/pandas-docs/stable/getting_started/install.html#recommended-dependencies
-    - numexpr >=2.6.8
+    - numexpr >=2.7.0
     - bottleneck >=1.2.1
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,13 +9,14 @@ source:
   sha256: c554e6c9cf2d5ea1aba5979cc837b3649539ced0e18ece186f055450c86622e2
 
 build:
-  number: 2
+  number: 3
   script:
     - export PYTHONUNBUFFERED=1  # [ppc64le]
     - {{ PYTHON }} -m pip install -vv --no-deps --ignore-installed .  # [not unix]
     - {{ PYTHON }} -m pip install -vv --no-deps --ignore-installed . --global-option="build_ext" --global-option="-j${CPU_COUNT}" --no-use-pep517  # [unix]
   entry_points:
     - matplotlib = pandas:plotting._matplotlib
+  skip: true  # [py<37]
 
 requirements:
   build:
@@ -41,7 +42,7 @@ requirements:
     - numexpr >=2.7.0
     - bottleneck >=1.2.1
   run_constrained:
-    - python >=3.7.1
+    - python !=3.7.0
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,6 @@ build:
     - {{ PYTHON }} -m pip install -vv --no-deps --ignore-installed . --global-option="build_ext" --global-option="-j${CPU_COUNT}" --no-use-pep517  # [unix]
   entry_points:
     - matplotlib = pandas:plotting._matplotlib
-  skip: true  # [py<37]
 
 requirements:
   build:
@@ -41,6 +40,8 @@ requirements:
     # see https://pandas.pydata.org/pandas-docs/stable/getting_started/install.html#recommended-dependencies
     - numexpr >=2.7.0
     - bottleneck >=1.2.1
+  run_constrained:
+    - python >=3.7.1
 
 test:
   requires:


### PR DESCRIPTION
Category: anaconda | subcategory: core | pkg_type: python
Popularity: 17423797 downloads - pandas 1.3.0 High-performance, easy-to-use data structures and data analysis tools.
Version change: bump version number from 1.2.5 to 1.3.0
license: BSD-3-Clause
Release date: Jul 2, 2021
Bug Tracker: many new open issues - a problem with performance and bugs https://github.com/pandas-dev/pandas/issues
Github releases: https://github.com/pandas-dev/pandas/releases
Changelog: https://pandas.pydata.org/pandas-docs/version/1.3.0/whatsnew/v1.3.0.html
License file: https://github.com/pandas-dev/pandas/blob/master/LICENSE
Upstream setup.cfg: https://github.com/pandas-dev/pandas/blob/master/setup.cfg and https://pandas.pydata.org/pandas-docs/version/1.3.0/whatsnew/v1.3.0.html#increased-minimum-versions-for-dependencies
Upstream setup.py: https://github.com/pandas-dev/pandas/blob/master/setup.py

Actions:
1. Update dependencies: numexpr >=2.7.0
2. Change version number and SHA256
3. Remove python >=3.7.1 and use that plain python to fix the build issuewhen no all py versions artifacts are created

Result:
- all-succeeded on concourse

