### PR TITLE
Rebuild pandas 1.4.1 for python 3.10 support on ppc64le

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,8 +11,7 @@ source:
     - 00001_fix_missing_date_month_table.patch  # [linux and aarch64]
 
 build:
-  number: 0
-  # trigger 1
+  number: 1
   script:
     - export PYTHONUNBUFFERED=1  # [ppc64le]
     - {{ PYTHON }} -m pip install -vv --no-deps --ignore-installed .  # [not unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,7 +32,7 @@ requirements:
     - cython >=0.29.24
     - numpy   1.19  # [not (osx and arm64) and (py==38 or py==39)]
     - numpy   1.21  # [(osx and arm64) and (py==38 or py==39)]
-    - numpy   1.21  # [not ppc64le and py==310]
+    - numpy   1.21  # [py==310]
     - setuptools >=51.0.0
     - wheel
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,7 @@ source:
 
 build:
   number: 0
+  # trigger 1
   script:
     - export PYTHONUNBUFFERED=1  # [ppc64le]
     - {{ PYTHON }} -m pip install -vv --no-deps --ignore-installed .  # [not unix]


### PR DESCRIPTION
statsmodels 0.13.2 requires it  for python 3.10 support on ppc64le