### PR TITLE
pandas 1.4.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.4.2" %}
+{% set version = "1.4.3" %}
 
 package:
   name: pandas
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/pandas-dev/pandas/releases/download/v{{ version }}/pandas-{{ version }}.tar.gz
-  sha256: 92bc1fc585f1463ca827b45535957815b7deb218c549b7c18402c322c7549a12
+  sha256: 2ff7788468e75917574f080cd4681b27e1a7bf36461fe968b49a87b5a54d007c
   patches:
     - 00001_fix_missing_date_month_table.patch  # [linux and aarch64]
 
@@ -28,7 +28,7 @@ requirements:
   host:
     - python
     - pip
-    - cython >=0.29.24
+    - cython >=0.29.24,<3
     - numpy   1.19  # [not (osx and arm64) and (py==38 or py==39)]
     - numpy   1.21  # [(osx and arm64) and (py==38 or py==39)]
     - numpy   1.21  # [py==310]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ requirements:
   host:
     - python
     - pip
-    - cython >=0.29.24,<3
+    - cython >=0.29.30,<3
     - numpy   1.19  # [not (osx and arm64) and (py==38 or py==39)]
     - numpy   1.21  # [(osx and arm64) and (py==38 or py==39)]
     - numpy   1.21  # [py==310]


### PR DESCRIPTION
Update pandas to 1.4.3

Bug Tracker: new open issues https://github.com/pandas-dev/pandas/issues
Changelog: https://pandas.pydata.org/pandas-docs/version/1.4.3/whatsnew/v1.4.3.html
Upstream license: License file: https://github.com/pandas-dev/pandas/blob/master/LICENSE
Upstream setup.cfg: https://github.com/pandas-dev/pandas/blob/v1.4.3/setup.cfg
Upstream setup.py: https://github.com/pandas-dev/pandas/blob/v1.4.3/setup.py
Upstream pyproject.toml: https://github.com/pandas-dev/pandas/blob/v1.4.3/pyproject.toml
Requirements: https://pandas.pydata.org/pandas-docs/version/1.4.3/getting_started/install.html#dependencies

Actions:
1. Fix pinning for cython