### PR TITLE
pandas 3.0.5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,23 @@
 {% set name = "pandas" %}
-{% set version = "3.0.3" %}
+{% set version = "3.0.5" %}
+{% set config_path = "{{ SRC_DIR }}/pyproject.toml" %}
+{% set markers = [
+  "not clipboard",
+  "not single_cpu",
+  "not slow",
+  "not network",
+  "not db"
+] %}
+{% set extra_args = ["-m " + " and ".join(markers)] %}
+{% set extra_args = 'extra_args + ["-ra -v -n auto"]' %}
+{% set extra_args = 'extra_args + ["-k", "not (" + tests_to_skip + ")", "--no-strict-data-files"]' %}
+{% set tests_to_skip = "_not_a_real_test" %}
+{% set tests_to_skip = 'tests_to_skip + " or TestDatetime64ArrayLikeComparisons or test_apply_out_of_range or TestNonNano or test_setitem_str_impute_tz or test_run_binary[ne-False-_integer_integers]"' %}  # [win]
+{% set tests_to_skip = tests_to_skip + " or test_scalar_unary" %}  # [py>=312]
+{% set tests_to_skip = 'tests_to_skip + " or test_array_inference[data7-expected7]"' %}
+{% set tests_to_skip = tests_to_skip + " or test_run_arithmetic or test_run_binary" %}  # [win]
+{% set tests_to_skip = tests_to_skip + " or test_binop_other or test_add_list_to_masked_array_boolean or test_bool_ops_warn_on_arithmetic" %}
+{% set tests_to_skip = tests_to_skip + " or test_simple_cmp_ops or test_compound_invert_op or test_simple_arith_ops" %}  # [py==314]
 
 package:
   name: {{ name|lower }}
@@ -7,7 +25,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 696a4a00a2a2a35d4e5deb3fc946641b96c944f02230e4f76137fe35d806c4fc
+  sha256: dca3734d6ab7c906e6730f0788b0a1dbb9f2467731f9711f77995c8e9d62d712
 
 build:
   number: 0
@@ -26,16 +44,17 @@ requirements:
     - ninja-base >=1.8.2
     - meson-python >=0.17.1,<1
     - meson >=1.2.1,<2
-    - cython >3.1.0,<4.0.0a0
+    - cython >3.1.0,<4
     - numpy {{ numpy }}
     - versioneer
     - wheel
   run:
     - python
     - numpy >=1.26.0  # [py<314]
-    - numpy >=2.3.3   # [py>=314]
+    - numpy >=2.3.3  # [py>=314]
     - python-dateutil >=2.8.2
-    - python-tzdata   # [win]
+    - python-tzdata  # [win]
+    - tzdata  # [emscripten]
   run_constrained:
     - adbc-driver-postgresql >=1.2.0
     - adbc-driver-sqlite >=1.2.0
@@ -55,7 +74,7 @@ requirements:
     - openpyxl >=3.1.5
     - psycopg2 >=2.9.10
     # tmp pyarrow upper bound, see https://github.com/pandas-dev/pandas/blob/v3.0.3/environment.yml#L46
-    - pyarrow >=13.0.0,<24
+    - pyarrow >=13.0.0
     - pyiceberg >=0.8.1
     - pymysql >=1.1.1
     # clipboard wants pyqt5 which we don't have
@@ -70,12 +89,13 @@ requirements:
     - qtpy >=2.4.2
     - scipy >=1.14.1
     - s3fs >=2024.10.0
-    - sqlalchemy >=2.0.36
+    - SQLAlchemy >=2.0.36
     - tabulate >=0.9.0
     - xarray >=2024.10.0
     - xlrd >=2.0.1
     - xlsxwriter >=3.2.0
     - zstandard >=0.23.0
+    - pyqt >=5.15.9
 
 test:
   source_files:
@@ -103,26 +123,14 @@ test:
   commands:
     - pip check
     - export LC_ALL=en_US.UTF-8  # [unix]
-    {% set config_path = "{{ SRC_DIR }}/pyproject.toml" %}
-    {% set markers = ["not clipboard", "not single_cpu", "not slow", "not network", "not db"] %}
-    {% set extra_args = ["-m " + " and ".join(markers)] %}
-    {% set extra_args = extra_args + ["-ra -v -n auto"] %}
-    {% set tests_to_skip = "_not_a_real_test" %}
     # skip windows tests which call _tz_localize_using_tzinfo_api - fails on CI but not when run on dev instance
     # OSError may be thrown by tzlocal on windows at or close to 1970-01-01
     #  see https://github.com/pandas-dev/pandas/pull/37591#issuecomment-720628241
-    {% set tests_to_skip = tests_to_skip + " or TestDatetime64ArrayLikeComparisons or test_apply_out_of_range or TestNonNano or test_setitem_str_impute_tz or test_run_binary[ne-False-_integer_integers]" %} # [win]
     # test_scalar_unary triggers python 3.12 DeprecationWarning: Bitwise inversion '~' on bool is deprecated.
-    {% set tests_to_skip = tests_to_skip + " or test_scalar_unary" %} # [py>=312]
     # Fixed in https://github.com/pandas-dev/pandas/pull/59016, not yet backported to 2.3
-    {% set tests_to_skip = tests_to_skip + " or test_array_inference[data7-expected7]" %}
     # Could be due to uninitialized memory
-    {% set tests_to_skip = tests_to_skip + " or test_run_arithmetic or test_run_binary" %} # [win]
     # Skip due to incompatibility with numexpr 2.14.1. TODO: Delete with pandas new release, see https://github.com/pandas-dev/pandas/pull/62553
-    {% set tests_to_skip = tests_to_skip + " or test_binop_other or test_add_list_to_masked_array_boolean or test_bool_ops_warn_on_arithmetic" %}
     # Skip tests that fail with python 3.14 due to new exception messages. Delete once fixed.
-    {% set tests_to_skip = tests_to_skip + " or test_simple_cmp_ops or test_compound_invert_op or test_simple_arith_ops" %} # [py==314]
-    {% set extra_args = extra_args + ["-k", "not (" + tests_to_skip + ")", "--no-strict-data-files"] %}
     # use --no-strict-data-files
     # xref: https://github.com/pandas-dev/pandas/issues/54907
     - python -c "import pandas; pandas.test(extra_args={{ extra_args }})"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,9 +33,9 @@ requirements:
   run:
     - python
     - numpy >=1.26.0  # [py<314]
-    - numpy >=2.3.3  # [py>=314]
+    - numpy >=2.3.3   # [py>=314]
     - python-dateutil >=2.8.2
-    - python-tzdata  # [win]
+    - python-tzdata   # [win]
   run_constrained:
     - adbc-driver-postgresql >=1.2.0
     - adbc-driver-sqlite >=1.2.0
@@ -54,7 +54,8 @@ requirements:
     - odfpy >=1.4.1
     - openpyxl >=3.1.5
     - psycopg2 >=2.9.10
-    - pyarrow >=13.0.0
+    # tmp pyarrow upper bound, see https://github.com/pandas-dev/pandas/blob/v3.0.5/environment.yml#L47
+    - pyarrow >=13.0.0,<24
     - pyiceberg >=0.8.1
     - pymysql >=1.1.1
     # clipboard wants pyqt5 which we don't have

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,23 +1,5 @@
 {% set name = "pandas" %}
 {% set version = "3.0.5" %}
-{% set config_path = "{{ SRC_DIR }}/pyproject.toml" %}
-{% set markers = [
-  "not clipboard",
-  "not single_cpu",
-  "not slow",
-  "not network",
-  "not db"
-] %}
-{% set extra_args = ["-m " + " and ".join(markers)] %}
-{% set extra_args = 'extra_args + ["-ra -v -n auto"]' %}
-{% set extra_args = 'extra_args + ["-k", "not (" + tests_to_skip + ")", "--no-strict-data-files"]' %}
-{% set tests_to_skip = "_not_a_real_test" %}
-{% set tests_to_skip = 'tests_to_skip + " or TestDatetime64ArrayLikeComparisons or test_apply_out_of_range or TestNonNano or test_setitem_str_impute_tz or test_run_binary[ne-False-_integer_integers]"' %}  # [win]
-{% set tests_to_skip = tests_to_skip + " or test_scalar_unary" %}  # [py>=312]
-{% set tests_to_skip = 'tests_to_skip + " or test_array_inference[data7-expected7]"' %}
-{% set tests_to_skip = tests_to_skip + " or test_run_arithmetic or test_run_binary" %}  # [win]
-{% set tests_to_skip = tests_to_skip + " or test_binop_other or test_add_list_to_masked_array_boolean or test_bool_ops_warn_on_arithmetic" %}
-{% set tests_to_skip = tests_to_skip + " or test_simple_cmp_ops or test_compound_invert_op or test_simple_arith_ops" %}  # [py==314]
 
 package:
   name: {{ name|lower }}
@@ -54,7 +36,6 @@ requirements:
     - numpy >=2.3.3  # [py>=314]
     - python-dateutil >=2.8.2
     - python-tzdata  # [win]
-    - tzdata  # [emscripten]
   run_constrained:
     - adbc-driver-postgresql >=1.2.0
     - adbc-driver-sqlite >=1.2.0
@@ -73,7 +54,6 @@ requirements:
     - odfpy >=1.4.1
     - openpyxl >=3.1.5
     - psycopg2 >=2.9.10
-    # tmp pyarrow upper bound, see https://github.com/pandas-dev/pandas/blob/v3.0.3/environment.yml#L46
     - pyarrow >=13.0.0
     - pyiceberg >=0.8.1
     - pymysql >=1.1.1
@@ -89,13 +69,12 @@ requirements:
     - qtpy >=2.4.2
     - scipy >=1.14.1
     - s3fs >=2024.10.0
-    - SQLAlchemy >=2.0.36
+    - sqlalchemy >=2.0.36
     - tabulate >=0.9.0
     - xarray >=2024.10.0
     - xlrd >=2.0.1
     - xlsxwriter >=3.2.0
     - zstandard >=0.23.0
-    - pyqt >=5.15.9
 
 test:
   source_files:
@@ -114,7 +93,7 @@ test:
     - pandas.util
   requires:
     - pip
-    - pytest >=8.3.4
+    - pytest >=8.3.4,<9.1
     - pytest-xdist >=3.6.1
     - pytest-qt >=4.4.0
     - hypothesis >=6.116.0
@@ -123,14 +102,26 @@ test:
   commands:
     - pip check
     - export LC_ALL=en_US.UTF-8  # [unix]
+    {% set config_path = "{{ SRC_DIR }}/pyproject.toml" %}
+    {% set markers = ["not clipboard", "not single_cpu", "not slow", "not network", "not db"] %}
+    {% set extra_args = ["-m " + " and ".join(markers)] %}
+    {% set extra_args = extra_args + ["-ra -v -n auto"] %}
+    {% set tests_to_skip = "_not_a_real_test" %}
     # skip windows tests which call _tz_localize_using_tzinfo_api - fails on CI but not when run on dev instance
     # OSError may be thrown by tzlocal on windows at or close to 1970-01-01
     #  see https://github.com/pandas-dev/pandas/pull/37591#issuecomment-720628241
+    {% set tests_to_skip = tests_to_skip + " or TestDatetime64ArrayLikeComparisons or test_apply_out_of_range or TestNonNano or test_setitem_str_impute_tz or test_run_binary[ne-False-_integer_integers]" %} # [win]
     # test_scalar_unary triggers python 3.12 DeprecationWarning: Bitwise inversion '~' on bool is deprecated.
+    {% set tests_to_skip = tests_to_skip + " or test_scalar_unary" %} # [py>=312]
     # Fixed in https://github.com/pandas-dev/pandas/pull/59016, not yet backported to 2.3
+    {% set tests_to_skip = tests_to_skip + " or test_array_inference[data7-expected7]" %}
     # Could be due to uninitialized memory
+    {% set tests_to_skip = tests_to_skip + " or test_run_arithmetic or test_run_binary" %} # [win]
     # Skip due to incompatibility with numexpr 2.14.1. TODO: Delete with pandas new release, see https://github.com/pandas-dev/pandas/pull/62553
+    {% set tests_to_skip = tests_to_skip + " or test_binop_other or test_add_list_to_masked_array_boolean or test_bool_ops_warn_on_arithmetic" %}
     # Skip tests that fail with python 3.14 due to new exception messages. Delete once fixed.
+    {% set tests_to_skip = tests_to_skip + " or test_simple_cmp_ops or test_compound_invert_op or test_simple_arith_ops" %} # [py==314]
+    {% set extra_args = extra_args + ["-k", "not (" + tests_to_skip + ")", "--no-strict-data-files"] %}
     # use --no-strict-data-files
     # xref: https://github.com/pandas-dev/pandas/issues/54907
     - python -c "import pandas; pandas.test(extra_args={{ extra_args }})"


### PR DESCRIPTION
**Links**
- Jira: https://anaconda.atlassian.net/browse/PKG-16675
- Project Dev URL: https://github.com/pandas-dev/pandas (tag v3.0.5)
- conda-forge recipe: https://github.com/conda-forge/pandas-feedstock
- PyPI: https://pypi.org/project/pandas/3.0.5
- PyPI Inspector: https://inspector.pypi.io/project/pandas/3.0.5

Bump pandas 3.0.3 → 3.0.5. Synced `cython`/`pytest` constraints with upstream `pyproject.toml` and fixed several issues introduced by the automated bump bot (misplaced/broken test-skip jinja logic, an invalid `emscripten` selector, a duplicate `pyqt` constraint, a stray `SQLAlchemy` casing change, and an incorrectly dropped `pyarrow<24` bound).

**Notes**
- The `pyarrow<24` cap in `run_constrained` is not from `pyproject.toml` — it mirrors a still-active temporary pin in pandas' own `environment.yml` (unchanged between 3.0.3 and 3.0.5) due to a live pyarrow 24.0 typing bug (apache/arrow#49831). `pyarrow` 23.0.1 is available in `main`, so the bound is satisfiable.
- conda-forge needed a source patch for pytest 9.1+ `parametrize` incompatibility (pandas-dev/pandas#65888); we avoid it by capping `pytest <9.1` in `test:requires`, matching `pyproject.toml`'s `test` extra — pytest 9.0.3 is available in `main`.